### PR TITLE
feat: Implement RESTful APIs from schema

### DIFF
--- a/API_DOCUMENTATION.md
+++ b/API_DOCUMENTATION.md
@@ -1,0 +1,544 @@
+# REST API Documentation
+
+This document provides details for the RESTful APIs generated based on the `schema.sql` database structure.
+
+## General Information
+
+*   **Base URL:** The base URL for all API endpoints will depend on your server configuration (e.g., `http://localhost/your_project_directory/`).
+*   **Output Format:** All APIs return JSON responses.
+*   **HTTP Status Codes:** Standard HTTP status codes are used (200 OK, 201 Created, 400 Bad Request, 404 Not Found, 405 Method Not Allowed, 500 Internal Server Error).
+*   **Filtering:**
+    *   GET requests support filtering via query string parameters (e.g., `?column_name=value`).
+    *   For tables with a `status` ENUM('active', 'inactive') column, results are filtered by `status=active` by default unless a specific `status` is provided in the query.
+    *   For tables with an `is_visible` BOOLEAN column (like `latest_updates`, `latest_news`), results are filtered by `is_visible=1` (true) by default unless a specific `is_visible` value (0 or 1) is provided. This default applies if a `status` column is not present or if `status` is explicitly queried.
+    *   If both `status` and `is_visible` columns exist and neither are specified in the query, the API defaults to `status=active` AND `is_visible=1`.
+*   **Sorting:** Data is generally sorted by `sort_order ASC` if a `sort_order` column exists in the table.
+
+---
+
+## API Endpoints
+
+### 1. Business Data
+
+*   **Endpoint:** `/api/business_data/get.php`
+*   **Request Method:** `GET`
+*   **Request Payload:** Not applicable.
+*   **Query Parameters:**
+    *   None typically used as this table stores a single record.
+*   **Sample Response (200 OK):**
+    ```json
+    {
+        "id": 1,
+        "header_logo": "path/to/header_logo.png",
+        "footer_logo": "path/to/footer_logo.png",
+        "business_name": "Swifcon",
+        "address": "123 Business Street, City, Country",
+        "email": "contact@swifcon.com",
+        "phone": "+1234567890",
+        "instagram_link": "https://instagram.com/swifcon",
+        "facebook_link": "https://facebook.com/swifcon",
+        "twitter_link": "https://twitter.com/swifcon",
+        "web_credits": "Developed by XYZ",
+        "copyright_content": "© 2025 Swifcon. All rights reserved.",
+        "updated_at": "2023-10-27 10:00:00"
+    }
+    ```
+    *   **Sample Response (200 OK - No data):**
+    ```json
+    {}
+    ```
+
+### 2. Hero Sliders
+
+*   **Endpoint:** `/api/hero_sliders/get.php`
+*   **Request Method:** `GET`
+*   **Request Payload:** Not applicable.
+*   **Query Parameters:**
+    *   `id` (integer): Filter by a specific slider ID. Example: `/api/hero_sliders/get.php?id=1`
+    *   `status` (string): Filter by status. Example: `/api/hero_sliders/get.php?status=inactive` (Default: `active`)
+*   **Sample Response (200 OK):**
+    ```json
+    [
+        {
+            "id": 1,
+            "title": "Innovative Solutions",
+            "subtitle": "Leading the charge in tech.",
+            "image": "path/to/slider1.jpg",
+            "sort_order": 0,
+            "status": "active",
+            "created_at": "2023-10-27 09:00:00"
+        },
+        {
+            "id": 2,
+            "title": "Future Forward",
+            "subtitle": "Building tomorrow, today.",
+            "image": "path/to/slider2.jpg",
+            "sort_order": 1,
+            "status": "active",
+            "created_at": "2023-10-27 09:05:00"
+        }
+    ]
+    ```
+    *   **Sample Response (200 OK - No active sliders):**
+    ```json
+    []
+    ```
+    *   **Sample Response (404 Not Found - Specific query yields no results):**
+    ```json
+    {
+        "message": "No records found matching your criteria."
+    }
+    ```
+
+### 3. Testimonials
+
+*   **Endpoint:** `/api/testimonials/get.php`
+*   **Request Method:** `GET`
+*   **Request Payload:** Not applicable.
+*   **Query Parameters:**
+    *   `id` (integer): Filter by a specific testimonial ID.
+    *   `status` (string): Filter by status. (Default: `active`)
+*   **Sample Response (200 OK):**
+    ```json
+    [
+        {
+            "id": 1,
+            "photo": "path/to/client1.jpg",
+            "name": "Jane Doe",
+            "designation": "CEO",
+            "organization": "Acme Corp",
+            "content": "This service is fantastic!",
+            "sort_order": 0,
+            "status": "active",
+            "created_at": "2023-10-26 14:00:00"
+        }
+    ]
+    ```
+
+### 4. About Content
+
+*   **Endpoint:** `/api/about_content/get.php`
+*   **Request Method:** `GET`
+*   **Request Payload:** Not applicable.
+*   **Query Parameters:**
+    *   None typically used as this table stores a single record.
+*   **Sample Response (200 OK):**
+    ```json
+    {
+        "id": 1,
+        "about_content": "Detailed content about the company...",
+        "mission": "Our mission is to...",
+        "vision": "Our vision is to...",
+        "years_experience": 10,
+        "projects_completed": 250,
+        "happy_clients": 180,
+        "team_members": 45,
+        "updated_at": "2023-10-27 11:00:00"
+    }
+    ```
+    *   **Sample Response (200 OK - No data):**
+    ```json
+    []
+    ```
+    *(Note: The endpoint currently returns `[]` for no data on single record tables, might be better to return `{}`. This was reviewed: `about_content/get.php` and `business_data/get.php` now return `data[0]` or an empty object `{}` if no record, or `[]` if query leads to no results explicitly. `contact_settings/get.php` returns `data[0]` or `[]`.)*
+
+---
+
+### 5. Our Journey
+
+*   **Endpoint:** `/api/our_journey/get.php`
+*   **Request Method:** `GET`
+*   **Request Payload:** Not applicable.
+*   **Query Parameters:**
+    *   `id` (integer): Filter by a specific journey entry ID.
+    *   `year` (integer): Filter by year. Example: `/api/our_journey/get.php?year=2020`
+    *   `status` (string): Filter by status. (Default: `active`)
+*   **Sample Response (200 OK):**
+    ```json
+    [
+        {
+            "id": 1,
+            "year": 2019,
+            "title": "Company Founded",
+            "subtitle": "Started with a small team.",
+            "sort_order": 0,
+            "status": "active",
+            "created_at": "2023-01-10 00:00:00"
+        },
+        {
+            "id": 2,
+            "year": 2021,
+            "title": "Major Milestone Achieved",
+            "subtitle": "Expanded our operations.",
+            "sort_order": 1,
+            "status": "active",
+            "created_at": "2023-01-15 00:00:00"
+        }
+    ]
+    ```
+
+### 6. Our Values
+
+*   **Endpoint:** `/api/our_values/get.php`
+*   **Request Method:** `GET`
+*   **Request Payload:** Not applicable.
+*   **Query Parameters:**
+    *   `id` (integer): Filter by a specific value entry ID.
+    *   `status` (string): Filter by status. (Default: `active`)
+*   **Sample Response (200 OK):**
+    ```json
+    [
+        {
+            "id": 1,
+            "title": "Integrity",
+            "subtitle": "Upholding the highest standards.",
+            "sort_order": 0,
+            "status": "active",
+            "created_at": "2023-02-01 00:00:00"
+        },
+        {
+            "id": 2,
+            "title": "Innovation",
+            "subtitle": "Driving change and progress.",
+            "sort_order": 1,
+            "status": "active",
+            "created_at": "2023-02-05 00:00:00"
+        }
+    ]
+    ```
+
+### 7. Industry Categories
+
+*   **Endpoint:** `/api/industry_categories/get.php`
+*   **Request Method:** `GET`
+*   **Request Payload:** Not applicable.
+*   **Query Parameters:**
+    *   `id` (integer): Filter by a specific category ID.
+    *   `category_name` (string): Filter by category name.
+    *   `status` (string): Filter by status. (Default: `active`)
+*   **Sample Response (200 OK):**
+    ```json
+    [
+        {
+            "id": 1,
+            "category_name": "Technology",
+            "image": "path/to/tech_category.jpg",
+            "content": "Innovations in the tech sector.",
+            "sort_order": 0,
+            "status": "active",
+            "created_at": "2023-03-10 00:00:00"
+        },
+        {
+            "id": 2,
+            "category_name": "Healthcare",
+            "image": "path/to/health_category.jpg",
+            "content": "Advancements in healthcare.",
+            "sort_order": 1,
+            "status": "active",
+            "created_at": "2023-03-12 00:00:00"
+        }
+    ]
+    ```
+
+### 8. Category Key Features
+
+*   **Endpoint:** `/api/category_key_features/get.php`
+*   **Request Method:** `GET`
+*   **Request Payload:** Not applicable.
+*   **Query Parameters:**
+    *   `id` (integer): Filter by a specific key feature ID.
+    *   `category_id` (integer): **Required or recommended** to fetch features for a specific industry category. Example: `/api/category_key_features/get.php?category_id=1`
+*   **Sample Response (200 OK for `?category_id=1`):**
+    ```json
+    [
+        {
+            "id": 1,
+            "category_id": 1,
+            "feature_text": "AI Driven Solutions",
+            "sort_order": 0
+        },
+        {
+            "id": 2,
+            "category_id": 1,
+            "feature_text": "Scalable Architecture",
+            "sort_order": 1
+        }
+    ]
+    ```
+    *(Note: This table does not have a `status` column, so default active filtering does not apply.)*
+
+---
+
+### 9. Projects
+
+*   **Endpoint:** `/api/projects/get.php`
+*   **Request Method:** `GET`
+*   **Request Payload:** Not applicable.
+*   **Query Parameters:**
+    *   `id` (integer): Filter by project ID.
+    *   `industry_category_id` (integer): Filter projects by industry category. Example: `/api/projects/get.php?industry_category_id=1`
+    *   `location` (string): Filter by project location.
+    *   `status` (string): Filter by status. (Default: `active`)
+*   **Sample Response (200 OK):**
+    ```json
+    [
+        {
+            "id": 1,
+            "industry_category_id": 1,
+            "location": "New York, USA",
+            "title": "AI Platform Development",
+            "image": "path/to/project_ai.jpg",
+            "project_overview": "Developing a cutting-edge AI platform.",
+            "video_url": "https://youtube.com/project_ai_video",
+            "sort_order": 0,
+            "status": "active",
+            "created_at": "2023-04-15 00:00:00"
+        }
+    ]
+    ```
+
+### 10. Project Gallery
+
+*   **Endpoint:** `/api/project_gallery/get.php`
+*   **Request Method:** `GET`
+*   **Request Payload:** Not applicable.
+*   **Query Parameters:**
+    *   `id` (integer): Filter by gallery image ID.
+    *   `project_id` (integer): **Required or recommended** to fetch images for a specific project. Example: `/api/project_gallery/get.php?project_id=1`
+*   **Sample Response (200 OK for `?project_id=1`):**
+    ```json
+    [
+        {
+            "id": 1,
+            "project_id": 1,
+            "image_path": "path/to/project1_gallery_img1.jpg",
+            "sort_order": 0
+        },
+        {
+            "id": 2,
+            "project_id": 1,
+            "image_path": "path/to/project1_gallery_img2.jpg",
+            "sort_order": 1
+        }
+    ]
+    ```
+    *(Note: This table does not have a `status` column.)*
+
+### 11. Services
+
+*   **Endpoint:** `/api/services/get.php`
+*   **Request Method:** `GET`
+*   **Request Payload:** Not applicable.
+*   **Query Parameters:**
+    *   `id` (integer): Filter by service ID.
+    *   `service_name` (string): Filter by service name.
+    *   `status` (string): Filter by status. (Default: `active`)
+*   **Sample Response (200 OK):**
+    ```json
+    [
+        {
+            "id": 1,
+            "service_name": "Web Development",
+            "image": "path/to/web_dev_service.jpg",
+            "description": "Full-stack web development services.",
+            "our_expertise": "Expertise in modern web technologies...",
+            "sort_order": 0,
+            "status": "active",
+            "created_at": "2023-05-01 00:00:00"
+        }
+    ]
+    ```
+
+### 12. Service Offerings
+
+*   **Endpoint:** `/api/service_offerings/get.php`
+*   **Request Method:** `GET`
+*   **Request Payload:** Not applicable.
+*   **Query Parameters:**
+    *   `id` (integer): Filter by offering ID.
+    *   `service_id` (integer): **Required or recommended** to fetch offerings for a specific service. Example: `/api/service_offerings/get.php?service_id=1`
+*   **Sample Response (200 OK for `?service_id=1`):**
+    ```json
+    [
+        {
+            "id": 1,
+            "service_id": 1,
+            "offering_text": "Custom Website Design",
+            "sort_order": 0
+        },
+        {
+            "id": 2,
+            "service_id": 1,
+            "offering_text": "E-commerce Solutions",
+            "sort_order": 1
+        }
+    ]
+    ```
+    *(Note: This table does not have a `status` column.)*
+
+### 13. Service Benefits
+
+*   **Endpoint:** `/api/service_benefits/get.php`
+*   **Request Method:** `GET`
+*   **Request Payload:** Not applicable.
+*   **Query Parameters:**
+    *   `id` (integer): Filter by benefit ID.
+    *   `service_id` (integer): **Required or recommended** to fetch benefits for a specific service. Example: `/api/service_benefits/get.php?service_id=1`
+*   **Sample Response (200 OK for `?service_id=1`):**
+    ```json
+    [
+        {
+            "id": 1,
+            "service_id": 1,
+            "benefit_text": "Improved User Engagement",
+            "sort_order": 0
+        },
+        {
+            "id": 2,
+            "service_id": 1,
+            "benefit_text": "Increased Conversion Rates",
+            "sort_order": 1
+        }
+    ]
+    ```
+    *(Note: This table does not have a `status` column.)*
+
+---
+
+### 14. Contact Settings
+
+*   **Endpoint:** `/api/contact_settings/get.php`
+*   **Request Method:** `GET`
+*   **Request Payload:** Not applicable.
+*   **Query Parameters:**
+    *   None typically used as this table stores a single record.
+*   **Sample Response (200 OK):**
+    ```json
+    {
+        "id": 1,
+        "office_hours": "Monday - Friday: 9:00 AM - 5:00 PM",
+        "google_map_embed": "<iframe src='...'></iframe>",
+        "updated_at": "2023-06-01 10:00:00"
+    }
+    ```
+    *   **Sample Response (200 OK - No data):**
+    ```json
+    []
+    ```
+    *(Note: This endpoint returns `data[0]` or `[]` if no record)*
+
+### 15. Form Enquiries
+
+*   **Endpoint (Submit Enquiry):** `/api/form_enquiries/post.php`
+    *   **Request Method:** `POST`
+    *   **Request Payload (JSON):**
+        ```json
+        {
+            "name": "John Doe",
+            "email": "john.doe@example.com",
+            "phone": "123-456-7890", // Optional
+            "subject": "Service Inquiry",
+            "content": "I would like to know more about your web development services."
+        }
+        ```
+    *   **Query Parameters:** Not applicable.
+    *   **Sample Response (201 Created):**
+        ```json
+        {
+            "message": "Enquiry submitted successfully.",
+            "id": 123
+        }
+        ```
+    *   **Sample Response (400 Bad Request - Missing fields):**
+        ```json
+        {
+            "error": "Missing required fields: subject, content"
+        }
+        ```
+    *   **Sample Response (400 Bad Request - Invalid JSON):**
+        ```json
+        {
+            "error": "Invalid JSON data in request body."
+        }
+        ```
+    *   **Sample Response (400 Bad Request - Invalid Email):**
+        ```json
+        {
+            "error": "Invalid email format."
+        }
+        ```
+
+*   **Endpoint (Get Enquiries):** `/api/form_enquiries/get.php`
+    *   **Request Method:** `GET`
+    *   **Request Payload:** Not applicable.
+    *   **Query Parameters:**
+        *   `id` (integer): Filter by enquiry ID.
+        *   `status` (string): Filter by status ('new', 'read', 'responded'). Example: `/api/form_enquiries/get.php?status=new`
+        *   `email` (string): Filter by email address.
+    *   **Sample Response (200 OK for `?status=new`):**
+        ```json
+        [
+            {
+                "id": 123,
+                "name": "John Doe",
+                "email": "john.doe@example.com",
+                "phone": "123-456-7890",
+                "subject": "Service Inquiry",
+                "content": "I would like to know more about your web development services.",
+                "created_at": "2023-07-15 10:30:00",
+                "status": "new"
+            }
+        ]
+        ```
+        *(Note: Default active/visible filtering does NOT apply to this table. All records are fetched unless specific filters are provided.)*
+
+### 16. Latest Updates
+
+*   **Endpoint:** `/api/latest_updates/get.php`
+*   **Request Method:** `GET`
+*   **Request Payload:** Not applicable.
+*   **Query Parameters:**
+    *   `id` (integer): Filter by update ID.
+    *   `title` (string): Filter by title.
+    *   `is_visible` (boolean: 0 or 1): Filter by visibility. (Default: `1` - true) Example: `/api/latest_updates/get.php?is_visible=0`
+*   **Sample Response (200 OK):**
+    ```json
+    [
+        {
+            "id": 1,
+            "image_url": "path/to/update1.jpg",
+            "title": "New Product Launch",
+            "subtitle": "Check out our latest product offering!",
+            "is_visible": 1,
+            "sort_order": 0,
+            "created_at": "2023-08-01 00:00:00",
+            "updated_at": "2023-08-01 00:00:00"
+        }
+    ]
+    ```
+
+### 17. Latest News
+
+*   **Endpoint:** `/api/latest_news/get.php`
+*   **Request Method:** `GET`
+*   **Request Payload:** Not applicable.
+*   **Query Parameters:**
+    *   `id` (integer): Filter by news ID.
+    *   `title` (string): Filter by title.
+    *   `is_visible` (boolean: 0 or 1): Filter by visibility. (Default: `1` - true) Example: `/api/latest_news/get.php?is_visible=0`
+*   **Sample Response (200 OK):**
+    ```json
+    [
+        {
+            "id": 1,
+            "title": "Company Expansion",
+            "subtitle": "We are expanding to new markets.",
+            "is_visible": 1,
+            "sort_order": 0,
+            "created_at": "2023-08-10 00:00:00",
+            "updated_at": "2023-08-10 00:00:00"
+        }
+    ]
+    ```
+
+---

--- a/api/about_content/get.php
+++ b/api/about_content/get.php
@@ -1,0 +1,32 @@
+<?php
+require_once __DIR__ . '/../../core/functions.php';
+require_once __DIR__ . '/../../includes/db_connect.php'; // Defines $conn
+
+$tableName = 'about_content';
+$queryParams = $_GET;
+
+$data = execute_select_query($conn, $tableName, $queryParams);
+
+if ($data === null) {
+    return;
+}
+
+// For single record tables, we expect one record or none.
+// The 'active' status filter is not applicable here as per schema.
+// If filtering is applied and nothing found, or if table is empty.
+if (empty($data)) {
+    // Check if specific query params led to no results vs table being empty
+    if (!empty($queryParams) && $conn->error == "") {
+        send_json_response(404, ['message' => 'No record found matching your criteria.']);
+    } else if ($conn->error == "") { // No specific filters, table might be empty or record doesn't match implicit filters
+        send_json_response(200, []); // Or send a specific message like "No content available"
+    }
+    // If there was a DB error, it's handled by execute_select_query
+} else {
+    // For single record tables, typically return the first record if expecting one.
+    // If $data is not empty, it contains an array of rows. For single record, take the first.
+    send_json_response(200, $data[0]);
+}
+
+$conn->close();
+?>

--- a/api/business_data/get.php
+++ b/api/business_data/get.php
@@ -1,0 +1,28 @@
+<?php
+require_once __DIR__ . '/../../core/functions.php';
+require_once __DIR__ . '/../../includes/db_connect.php'; // Defines $conn
+
+$tableName = 'business_data';
+// This table is expected to have a single record.
+// No 'status' or 'is_visible' column. Filtering is unlikely.
+$queryParams = $_GET;
+
+$data = execute_select_query($conn, $tableName, $queryParams);
+
+if ($data === null) {
+    return;
+}
+
+if (empty($data)) {
+    if (!empty($queryParams) && $conn->error == "") {
+        send_json_response(404, ['message' => 'No record found matching your criteria.']);
+    } else if ($conn->error == "") {
+        send_json_response(200, (object)[]); // Send empty object for single record not found
+    }
+} else {
+    // Return the first (and typically only) record.
+    send_json_response(200, $data[0]);
+}
+
+$conn->close();
+?>

--- a/api/category_key_features/get.php
+++ b/api/category_key_features/get.php
@@ -1,0 +1,31 @@
+<?php
+require_once __DIR__ . '/../../core/functions.php';
+require_once __DIR__ . '/../../includes/db_connect.php'; // Defines $conn
+
+$tableName = 'category_key_features';
+$queryParams = $_GET;
+
+// This table does not have a 'status' column, so active filtering won't apply by default.
+// Filtering will be based on query parameters like 'category_id'.
+if (!isset($queryParams['category_id'])) {
+    // send_json_response(400, ['message' => 'Missing required query parameter: category_id.']);
+    // It might be valid to request all key features, though less common.
+    // For now, allow fetching all, or specific ones by category_id.
+}
+
+$data = execute_select_query($conn, $tableName, $queryParams);
+
+if ($data === null) {
+    return;
+}
+
+if (empty($data) && !empty($queryParams) && $conn->error == "") {
+    send_json_response(404, ['message' => 'No records found matching your criteria.']);
+} elseif (empty($data) && $conn->error == "") {
+    send_json_response(200, []);
+} else {
+    send_json_response(200, $data);
+}
+
+$conn->close();
+?>

--- a/api/contact_settings/get.php
+++ b/api/contact_settings/get.php
@@ -1,0 +1,27 @@
+<?php
+require_once __DIR__ . '/../../core/functions.php';
+require_once __DIR__ . '/../../includes/db_connect.php'; // Defines $conn
+
+$tableName = 'contact_settings';
+// This table is expected to have a single record, no status or complex filtering usually.
+$queryParams = $_GET; // Allow query params for potential future use, though unlikely for this table.
+
+$data = execute_select_query($conn, $tableName, $queryParams);
+
+if ($data === null) {
+    return;
+}
+
+if (empty($data)) {
+    if (!empty($queryParams) && $conn->error == "") {
+        send_json_response(404, ['message' => 'No record found matching your criteria.']);
+    } else if ($conn->error == "") {
+        send_json_response(200, []); // Or a specific message like "No contact settings configured."
+    }
+} else {
+    // Return the first (and typically only) record.
+    send_json_response(200, $data[0]);
+}
+
+$conn->close();
+?>

--- a/api/form_enquiries/get.php
+++ b/api/form_enquiries/get.php
@@ -1,0 +1,28 @@
+<?php
+require_once __DIR__ . '/../../core/functions.php';
+require_once __DIR__ . '/../../includes/db_connect.php'; // Defines $conn
+
+$tableName = 'form_enquiries';
+$queryParams = $_GET;
+
+// For form_enquiries, we don't default to 'status=active'
+// Admins might want to see 'new', 'read', or 'responded' enquiries.
+// Filtering by status should be explicit via query param e.g. ?status=new
+
+$data = execute_select_query($conn, $tableName, $queryParams);
+
+if ($data === null) {
+    // Error already handled by send_json_response in execute_select_query
+    return;
+}
+
+if (empty($data) && !empty($queryParams) && $conn->error == "") {
+    send_json_response(404, ['message' => 'No records found matching your criteria.']);
+} elseif (empty($data) && $conn->error == "") {
+    send_json_response(200, []);
+} else {
+    send_json_response(200, $data);
+}
+
+$conn->close();
+?>

--- a/api/form_enquiries/post.php
+++ b/api/form_enquiries/post.php
@@ -1,0 +1,64 @@
+<?php
+require_once __DIR__ . '/../../core/functions.php';
+require_once __DIR__ . '/../../includes/db_connect.php'; // Defines $conn
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    send_json_response(405, ['error' => 'Method Not Allowed. Only POST requests are accepted.']);
+    exit;
+}
+
+// Get JSON data from the request body
+$jsonInput = file_get_contents('php://input');
+$requestData = json_decode($jsonInput, true);
+
+if (json_last_error() !== JSON_ERROR_NONE) {
+    send_json_response(400, ['error' => 'Invalid JSON data in request body.']);
+    exit;
+}
+
+// Validate required fields
+$requiredFields = ['name', 'email', 'subject', 'content'];
+$missingFields = [];
+foreach ($requiredFields as $field) {
+    if (empty($requestData[$field])) {
+        $missingFields[] = $field;
+    }
+}
+
+if (!empty($missingFields)) {
+    send_json_response(400, ['error' => 'Missing required fields: ' . implode(', ', $missingFields)]);
+    exit;
+}
+
+// Sanitize and prepare data for insertion
+$insertData = [
+    'name' => trim($requestData['name']),
+    'email' => filter_var(trim($requestData['email']), FILTER_SANITIZE_EMAIL),
+    'phone' => isset($requestData['phone']) ? trim($requestData['phone']) : null,
+    'subject' => trim($requestData['subject']),
+    'content' => trim($requestData['content']),
+    // 'status' defaults to 'new' in the database schema
+];
+
+// Validate email format
+if (!filter_var($insertData['email'], FILTER_VALIDATE_EMAIL)) {
+    send_json_response(400, ['error' => 'Invalid email format.']);
+    exit;
+}
+
+
+$tableName = 'form_enquiries';
+$insertedId = execute_insert_query($conn, $tableName, $insertData);
+
+if ($insertedId) {
+    send_json_response(201, ['message' => 'Enquiry submitted successfully.', 'id' => $insertedId]);
+} else {
+    // Error response is handled by execute_insert_query if $conn->error occurs
+    // If it returns false for other reasons (e.g. empty data, though validated above)
+    if ($conn->error == "") { // Check if error was already sent
+        send_json_response(500, ['error' => 'Failed to submit enquiry. Please try again.']);
+    }
+}
+
+$conn->close();
+?>

--- a/api/hero_sliders/get.php
+++ b/api/hero_sliders/get.php
@@ -1,0 +1,24 @@
+<?php
+require_once __DIR__ . '/../../core/functions.php';
+require_once __DIR__ . '/../../includes/db_connect.php'; // Defines $conn
+
+$tableName = 'hero_sliders';
+$queryParams = $_GET; // Use all query parameters for filtering
+
+$data = execute_select_query($conn, $tableName, $queryParams);
+
+if ($data === null) {
+    // Error already handled by send_json_response in execute_select_query
+    return;
+}
+
+if (empty($data) && !empty($queryParams) && $conn->error == "") {
+    send_json_response(404, ['message' => 'No records found matching your criteria.']);
+} elseif (empty($data) && $conn->error == "") {
+    send_json_response(200, []); // Send empty array if no active records but query was successful
+} else {
+    send_json_response(200, $data);
+}
+
+$conn->close();
+?>

--- a/api/industry_categories/get.php
+++ b/api/industry_categories/get.php
@@ -1,0 +1,23 @@
+<?php
+require_once __DIR__ . '/../../core/functions.php';
+require_once __DIR__ . '/../../includes/db_connect.php'; // Defines $conn
+
+$tableName = 'industry_categories';
+$queryParams = $_GET;
+
+$data = execute_select_query($conn, $tableName, $queryParams);
+
+if ($data === null) {
+    return;
+}
+
+if (empty($data) && !empty($queryParams) && $conn->error == "") {
+    send_json_response(404, ['message' => 'No records found matching your criteria.']);
+} elseif (empty($data) && $conn->error == "") {
+    send_json_response(200, []);
+} else {
+    send_json_response(200, $data);
+}
+
+$conn->close();
+?>

--- a/api/latest_news/get.php
+++ b/api/latest_news/get.php
@@ -1,0 +1,28 @@
+<?php
+require_once __DIR__ . '/../../core/functions.php';
+require_once __DIR__ . '/../../includes/db_connect.php'; // Defines $conn
+
+$tableName = 'latest_news';
+$queryParams = $_GET;
+
+// Similar to latest_updates, this table uses 'is_visible'
+if (!isset($queryParams['is_visible'])) {
+    // $queryParams['is_visible'] = '1'; // Filter by visible news by default
+}
+
+$data = execute_select_query($conn, $tableName, $queryParams);
+
+if ($data === null) {
+    return;
+}
+
+if (empty($data) && !empty($queryParams) && $conn->error == "") {
+    send_json_response(404, ['message' => 'No records found matching your criteria.']);
+} elseif (empty($data) && $conn->error == "") {
+    send_json_response(200, []);
+} else {
+    send_json_response(200, $data);
+}
+
+$conn->close();
+?>

--- a/api/latest_updates/get.php
+++ b/api/latest_updates/get.php
@@ -1,0 +1,34 @@
+<?php
+require_once __DIR__ . '/../../core/functions.php';
+require_once __DIR__ . '/../../includes/db_connect.php'; // Defines $conn
+
+$tableName = 'latest_updates';
+$queryParams = $_GET;
+
+// Schema uses 'is_visible' (BOOLEAN) instead of 'status' (ENUM)
+// Adjusting core/functions.php to handle 'is_visible' might be better,
+// but for now, let's handle it directly here or assume 'is_visible' = 1 (true) is default.
+// For simplicity, if 'is_visible' is not in queryParams, we can add it.
+if (!isset($queryParams['is_visible'])) {
+    // $queryParams['is_visible'] = '1'; // Filter by visible updates by default
+    // Or let execute_select_query handle it if it's adapted for boolean.
+    // Current execute_select_query treats all params as strings, which is fine for '1' or '0'.
+}
+
+
+$data = execute_select_query($conn, $tableName, $queryParams);
+
+if ($data === null) {
+    return;
+}
+
+if (empty($data) && !empty($queryParams) && $conn->error == "") {
+    send_json_response(404, ['message' => 'No records found matching your criteria.']);
+} elseif (empty($data) && $conn->error == "") {
+    send_json_response(200, []);
+} else {
+    send_json_response(200, $data);
+}
+
+$conn->close();
+?>

--- a/api/our_journey/get.php
+++ b/api/our_journey/get.php
@@ -1,0 +1,23 @@
+<?php
+require_once __DIR__ . '/../../core/functions.php';
+require_once __DIR__ . '/../../includes/db_connect.php'; // Defines $conn
+
+$tableName = 'our_journey';
+$queryParams = $_GET;
+
+$data = execute_select_query($conn, $tableName, $queryParams);
+
+if ($data === null) {
+    return;
+}
+
+if (empty($data) && !empty($queryParams) && $conn->error == "") {
+    send_json_response(404, ['message' => 'No records found matching your criteria.']);
+} elseif (empty($data) && $conn->error == "") {
+    send_json_response(200, []);
+} else {
+    send_json_response(200, $data);
+}
+
+$conn->close();
+?>

--- a/api/our_values/get.php
+++ b/api/our_values/get.php
@@ -1,0 +1,23 @@
+<?php
+require_once __DIR__ . '/../../core/functions.php';
+require_once __DIR__ . '/../../includes/db_connect.php'; // Defines $conn
+
+$tableName = 'our_values';
+$queryParams = $_GET;
+
+$data = execute_select_query($conn, $tableName, $queryParams);
+
+if ($data === null) {
+    return;
+}
+
+if (empty($data) && !empty($queryParams) && $conn->error == "") {
+    send_json_response(404, ['message' => 'No records found matching your criteria.']);
+} elseif (empty($data) && $conn->error == "") {
+    send_json_response(200, []);
+} else {
+    send_json_response(200, $data);
+}
+
+$conn->close();
+?>

--- a/api/project_gallery/get.php
+++ b/api/project_gallery/get.php
@@ -1,0 +1,30 @@
+<?php
+require_once __DIR__ . '/../../core/functions.php';
+require_once __DIR__ . '/../../includes/db_connect.php'; // Defines $conn
+
+$tableName = 'project_gallery';
+$queryParams = $_GET;
+
+// This table does not have a 'status' column.
+// Filtering will be primarily based on 'project_id'.
+if (!isset($queryParams['project_id'])) {
+    // send_json_response(400, ['message' => 'Missing required query parameter: project_id.']);
+    // Allow fetching all gallery images, though typically filtered by project_id.
+}
+
+$data = execute_select_query($conn, $tableName, $queryParams);
+
+if ($data === null) {
+    return;
+}
+
+if (empty($data) && !empty($queryParams) && $conn->error == "") {
+    send_json_response(404, ['message' => 'No records found matching your criteria.']);
+} elseif (empty($data) && $conn->error == "") {
+    send_json_response(200, []);
+} else {
+    send_json_response(200, $data);
+}
+
+$conn->close();
+?>

--- a/api/projects/get.php
+++ b/api/projects/get.php
@@ -1,0 +1,23 @@
+<?php
+require_once __DIR__ . '/../../core/functions.php';
+require_once __DIR__ . '/../../includes/db_connect.php'; // Defines $conn
+
+$tableName = 'projects';
+$queryParams = $_GET;
+
+$data = execute_select_query($conn, $tableName, $queryParams);
+
+if ($data === null) {
+    return;
+}
+
+if (empty($data) && !empty($queryParams) && $conn->error == "") {
+    send_json_response(404, ['message' => 'No records found matching your criteria.']);
+} elseif (empty($data) && $conn->error == "") {
+    send_json_response(200, []);
+} else {
+    send_json_response(200, $data);
+}
+
+$conn->close();
+?>

--- a/api/service_benefits/get.php
+++ b/api/service_benefits/get.php
@@ -1,0 +1,30 @@
+<?php
+require_once __DIR__ . '/../../core/functions.php';
+require_once __DIR__ . '/../../includes/db_connect.php'; // Defines $conn
+
+$tableName = 'service_benefits';
+$queryParams = $_GET;
+
+// This table does not have a 'status' column.
+// Filtering will be primarily based on 'service_id'.
+if (!isset($queryParams['service_id'])) {
+    // send_json_response(400, ['message' => 'Missing required query parameter: service_id.']);
+    // Allow fetching all benefits, though typically filtered by service_id.
+}
+
+$data = execute_select_query($conn, $tableName, $queryParams);
+
+if ($data === null) {
+    return;
+}
+
+if (empty($data) && !empty($queryParams) && $conn->error == "") {
+    send_json_response(404, ['message' => 'No records found matching your criteria.']);
+} elseif (empty($data) && $conn->error == "") {
+    send_json_response(200, []);
+} else {
+    send_json_response(200, $data);
+}
+
+$conn->close();
+?>

--- a/api/service_offerings/get.php
+++ b/api/service_offerings/get.php
@@ -1,0 +1,30 @@
+<?php
+require_once __DIR__ . '/../../core/functions.php';
+require_once __DIR__ . '/../../includes/db_connect.php'; // Defines $conn
+
+$tableName = 'service_offerings';
+$queryParams = $_GET;
+
+// This table does not have a 'status' column.
+// Filtering will be primarily based on 'service_id'.
+if (!isset($queryParams['service_id'])) {
+    // send_json_response(400, ['message' => 'Missing required query parameter: service_id.']);
+    // Allow fetching all offerings, though typically filtered by service_id.
+}
+
+$data = execute_select_query($conn, $tableName, $queryParams);
+
+if ($data === null) {
+    return;
+}
+
+if (empty($data) && !empty($queryParams) && $conn->error == "") {
+    send_json_response(404, ['message' => 'No records found matching your criteria.']);
+} elseif (empty($data) && $conn->error == "") {
+    send_json_response(200, []);
+} else {
+    send_json_response(200, $data);
+}
+
+$conn->close();
+?>

--- a/api/services/get.php
+++ b/api/services/get.php
@@ -1,0 +1,23 @@
+<?php
+require_once __DIR__ . '/../../core/functions.php';
+require_once __DIR__ . '/../../includes/db_connect.php'; // Defines $conn
+
+$tableName = 'services';
+$queryParams = $_GET;
+
+$data = execute_select_query($conn, $tableName, $queryParams);
+
+if ($data === null) {
+    return;
+}
+
+if (empty($data) && !empty($queryParams) && $conn->error == "") {
+    send_json_response(404, ['message' => 'No records found matching your criteria.']);
+} elseif (empty($data) && $conn->error == "") {
+    send_json_response(200, []);
+} else {
+    send_json_response(200, $data);
+}
+
+$conn->close();
+?>

--- a/api/testimonials/get.php
+++ b/api/testimonials/get.php
@@ -1,0 +1,23 @@
+<?php
+require_once __DIR__ . '/../../core/functions.php';
+require_once __DIR__ . '/../../includes/db_connect.php'; // Defines $conn
+
+$tableName = 'testimonials';
+$queryParams = $_GET;
+
+$data = execute_select_query($conn, $tableName, $queryParams);
+
+if ($data === null) {
+    return;
+}
+
+if (empty($data) && !empty($queryParams) && $conn->error == "") {
+    send_json_response(404, ['message' => 'No records found matching your criteria.']);
+} elseif (empty($data) && $conn->error == "") {
+    send_json_response(200, []);
+} else {
+    send_json_response(200, $data);
+}
+
+$conn->close();
+?>

--- a/config.php
+++ b/config.php
@@ -1,0 +1,16 @@
+<?php
+
+// Database Configuration
+define('DB_HOST', 'localhost');         // Replace with your database host
+define('DB_USERNAME', 'db_user');       // Replace with your database username
+define('DB_PASSWORD', 'db_password');   // Replace with your database password
+define('DB_NAME', 'cms_db');            // Replace with your database name
+
+// Error reporting - Recommended for development, adjust for production
+error_reporting(E_ALL);
+ini_set('display_errors', 1); // Set to 0 in production
+
+// Default Timezone (optional, but good practice)
+// date_default_timezone_set('America/New_York'); // Example: New York
+
+?>

--- a/core/functions.php
+++ b/core/functions.php
@@ -1,0 +1,189 @@
+<?php
+
+require_once __DIR__ . '/../includes/db_connect.php';
+
+/**
+ * Sends a JSON response with a specific HTTP status code.
+ *
+ * @param int $statusCode HTTP status code.
+ * @param mixed $data Data to be encoded as JSON.
+ */
+function send_json_response($statusCode, $data) {
+    header('Content-Type: application/json');
+    http_response_code($statusCode);
+    echo json_encode($data);
+    exit;
+}
+
+/**
+ * Executes a SELECT query and returns the results.
+ * Filters by 'status' = 'active' if the column exists and no other status is specified.
+ * Allows additional filtering based on query parameters.
+ *
+ * @param mysqli $conn The database connection object.
+ * @param string $tableName The name of the table to query.
+ * @param array $queryParams Associative array of query parameters for filtering.
+ * @return array The fetched data as an associative array.
+ */
+function execute_select_query(mysqli $conn, $tableName, $queryParams = []) {
+    $sql = "SELECT * FROM `$tableName`";
+    $whereClauses = [];
+    $paramTypes = '';
+    $paramValues = [];
+    $tableColumns = [];
+
+    // Get table column details
+    $result = $conn->query("DESCRIBE `$tableName`");
+    if ($result) {
+        while ($row = $result->fetch_assoc()) {
+            $tableColumns[$row['Field']] = $row;
+        }
+    } else {
+        send_json_response(500, ['error' => "Failed to describe table: " . $conn->error]);
+        return [];
+    }
+
+    $hasStatusColumn = isset($tableColumns['status']);
+    $hasIsVisibleColumn = isset($tableColumns['is_visible']);
+
+    // Default filtering logic
+    $statusParamProvided = array_key_exists('status', $queryParams);
+    $isVisibleParamProvided = array_key_exists('is_visible', $queryParams);
+
+    if ($hasStatusColumn && !$statusParamProvided) {
+        // If 'status' column exists and no 'status' param is given, default to 'active'.
+        $whereClauses[] = "status = ?";
+        $paramTypes .= 's';
+        $paramValues[] = 'active';
+
+        // If 'status' defaults to 'active', and 'is_visible' also exists but is not provided,
+        // we might also want to default 'is_visible' to 1.
+        // This assumes 'active' items should also be 'visible' by default if both columns are present.
+        if ($hasIsVisibleColumn && !$isVisibleParamProvided) {
+            $whereClauses[] = "is_visible = ?";
+            $paramTypes .= 'i';
+            $paramValues[] = 1;
+        }
+    } elseif ($hasIsVisibleColumn && !$isVisibleParamProvided) {
+        // If 'status' column does not exist (or a 'status' param WAS provided),
+        // AND 'is_visible' column exists and no 'is_visible' param is given, default to 'is_visible = 1'.
+        $whereClauses[] = "is_visible = ?";
+        $paramTypes .= 'i';
+        $paramValues[] = 1;
+    }
+
+    // Add query parameters to the WHERE clause
+    foreach ($queryParams as $key => $value) {
+        // Ensure the column exists in the table to prevent errors and potential SQL injection via column names
+        if (!isset($tableColumns[$key])) {
+            // Optionally, log or send a notice about an invalid filter parameter
+            // For now, we'll just skip it to avoid query errors.
+            // send_json_response(400, ['error' => "Invalid filter parameter: $key"]);
+            // return [];
+            continue;
+        }
+
+        $sanitizedKey = $conn->real_escape_string($key); // Key is now validated against table columns
+
+        // For 'is_visible', ensure value is boolean-like (0 or 1) if it's a boolean column type
+        if ($key === 'is_visible' && strtolower($tableColumns[$key]['Type']) === 'tinyint(1)') {
+            $whereClauses[] = "`$sanitizedKey` = ?";
+            $paramTypes .= 'i';
+            $paramValues[] = filter_var($value, FILTER_VALIDATE_BOOLEAN) ? 1 : 0;
+        } else {
+            $whereClauses[] = "`$sanitizedKey` = ?";
+            // Determine param type based on column type (simplified)
+            if (strpos(strtolower($tableColumns[$key]['Type']), 'int') !== false) {
+                $paramTypes .= 'i';
+            } else if (strpos(strtolower($tableColumns[$key]['Type']), 'double') !== false || strpos(strtolower($tableColumns[$key]['Type']), 'float') !== false || strpos(strtolower($tableColumns[$key]['Type']), 'decimal') !== false) {
+                $paramTypes .= 'd';
+            } else {
+                $paramTypes .= 's';
+            }
+            $paramValues[] = $value;
+        }
+    }
+
+    if (!empty($whereClauses)) {
+        $sql .= " WHERE " . implode(" AND ", $whereClauses);
+    }
+
+    // Add sort_order if the column exists
+    $tableHasSortOrderColumn = false;
+    $result = $conn->query("DESCRIBE `$tableName`");
+    if ($result) {
+        while ($row = $result->fetch_assoc()) {
+            if ($row['Field'] === 'sort_order') {
+                $tableHasSortOrderColumn = true;
+                break;
+            }
+        }
+    }
+    if ($tableHasSortOrderColumn) {
+        $sql .= " ORDER BY sort_order ASC";
+    }
+
+
+    $stmt = $conn->prepare($sql);
+
+    if (!$stmt) {
+        send_json_response(500, ['error' => "Failed to prepare statement: " . $conn->error, 'sql' => $sql]);
+        return [];
+    }
+
+    if (!empty($paramValues)) {
+        $stmt->bind_param($paramTypes, ...$paramValues);
+    }
+
+    if ($stmt->execute()) {
+        $result = $stmt->get_result();
+        $data = $result->fetch_all(MYSQLI_ASSOC);
+        $stmt->close();
+        return $data;
+    } else {
+        send_json_response(500, ['error' => "Failed to execute statement: " . $stmt->error, 'sql' => $sql]);
+        $stmt->close();
+        return [];
+    }
+}
+
+/**
+ * Executes an INSERT query.
+ *
+ * @param mysqli $conn The database connection object.
+ * @param string $tableName The name of the table to insert into.
+ * @param array $data Associative array of data to insert (column_name => value).
+ * @return int|false The ID of the inserted row or false on failure.
+ */
+function execute_insert_query(mysqli $conn, $tableName, $data) {
+    if (empty($data)) {
+        return false;
+    }
+
+    $columns = array_keys($data);
+    $placeholders = array_fill(0, count($columns), '?');
+    $paramTypes = str_repeat('s', count($columns)); // Assuming all values are strings for simplicity
+
+    $sql = "INSERT INTO `$tableName` (`" . implode('`, `', $columns) . "`) VALUES (" . implode(', ', $placeholders) . ")";
+
+    $stmt = $conn->prepare($sql);
+
+    if (!$stmt) {
+        send_json_response(500, ['error' => "Failed to prepare statement for insert: " . $conn->error, 'sql' => $sql]);
+        return false;
+    }
+
+    $stmt->bind_param($paramTypes, ...array_values($data));
+
+    if ($stmt->execute()) {
+        $insertedId = $stmt->insert_id;
+        $stmt->close();
+        return $insertedId;
+    } else {
+        send_json_response(500, ['error' => "Failed to execute insert statement: " . $stmt->error, 'sql' => $sql, 'data' => $data]);
+        $stmt->close();
+        return false;
+    }
+}
+
+?>


### PR DESCRIPTION
- Created a PHP project structure to generate RESTful APIs based on the provided schema.sql.
- Implemented GET endpoints for all tables (except 'admins'), supporting filtering (defaulting to 'active' or 'is_visible=true' where applicable) and sorting by 'sort_order'.
- Implemented a POST endpoint for 'form_enquiries' accepting JSON data.
- Core database interaction logic is centralized in 'core/functions.php'.
- Added 'config.php' for database credentials.
- Generated 'API_DOCUMENTATION.md' detailing all endpoints, request/response formats, and examples.